### PR TITLE
Cleanup: CSS styling + FilterHadithSidebar drag and drop animation

### DIFF
--- a/src/components/FilterHadithSidebar.tsx
+++ b/src/components/FilterHadithSidebar.tsx
@@ -9,12 +9,46 @@ type Props = {
   toggleSidebar?: () => void;
 };
 
+const CLOSE_DRAG_THRESHOLD = 150;
+const DRAG_RESISTANCE = 0.7;
+const ANIMATION_MS = 320;
+
 const FilterHadithSidebar = ({ isSidebarOpen, toggleSidebar }: Props) => {
   const sidebarRef = useRef<HTMLDivElement>(null);
   const touchStartY = useRef<number | null>(null);
   const lastScrollTop = useRef(0);
+
   const [dragOffset, setDragOffset] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
+  const [isMounted, setIsMounted] = useState(isSidebarOpen);
+  const [isVisible, setIsVisible] = useState(isSidebarOpen);
+  const [isDesktop, setIsDesktop] = useState(
+    () => window.matchMedia("(min-width: 768px)").matches,
+  );
+
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 768px)");
+    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  // Double-RAF guarantees the "hidden" frame is painted before transitioning in,
+  // preventing the jitter of a skipped initial frame.
+  useEffect(() => {
+    if (isSidebarOpen) {
+      setIsMounted(true);
+      const raf = requestAnimationFrame(() =>
+        requestAnimationFrame(() => setIsVisible(true)),
+      );
+      return () => cancelAnimationFrame(raf);
+    } else {
+      setIsVisible(false);
+      const t = setTimeout(() => setIsMounted(false), ANIMATION_MS);
+      return () => clearTimeout(t);
+    }
+  }, [isSidebarOpen]);
+
   const {
     showBookmarks,
     setShowBookmarks,
@@ -32,108 +66,71 @@ const FilterHadithSidebar = ({ isSidebarOpen, toggleSidebar }: Props) => {
 
   const [localSearchTerm, setLocalSearchTerm] = useState(searchTerm);
 
-  useEffect(() => {
-    setLocalSearchTerm(searchTerm);
-  }, [searchTerm]);
+  useEffect(() => setLocalSearchTerm(searchTerm), [searchTerm]);
 
-  const debouncedSetQuery = useCallback(
-    debounce((query: string) => {
-      setSearchTerm(query);
-    }, 500),
-    [setSearchTerm]
-  );
+  const debouncedSetQuery = useRef(
+    debounce((query: string) => setSearchTerm(query), 500),
+  ).current;
 
-  const handleQuery: React.ChangeEventHandler<HTMLInputElement> = (event) => {
-    event.preventDefault();
-    const query = event.currentTarget.value;
+  useEffect(() => () => debouncedSetQuery.cancel(), [debouncedSetQuery]);
 
+  const handleQuery: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    const query = e.currentTarget.value;
     setLocalSearchTerm(query);
-
     debouncedSetQuery(query);
   };
 
-  useEffect(() => {
-    return () => {
-      debouncedSetQuery.cancel();
-    };
-  }, [debouncedSetQuery]);
-
-  // Handle touch start event
   const handleTouchStart = (e: React.TouchEvent) => {
-    // Only enable dragging if we're near the top of the content or at the drag handle
-    const isAtTop = sidebarRef.current?.scrollTop === 0;
     const target = e.target as HTMLElement;
     const isDragHandle =
       target.classList.contains("drag-handle") ||
       target.parentElement?.classList.contains("drag-handle");
 
-    if (isAtTop || isDragHandle) {
+    if (sidebarRef.current?.scrollTop === 0 || isDragHandle) {
       touchStartY.current = e.touches[0].clientY;
       setIsDragging(true);
     }
   };
 
-  // Handle touch move event
   const handleTouchMove = (e: React.TouchEvent) => {
     if (touchStartY.current === null || !isDragging) return;
-
-    // Get current touch position
-    const touchY = e.touches[0].clientY;
-    const diff = touchY - touchStartY.current;
-
-    // Only allow downward drag (positive diff)
+    const diff = e.touches[0].clientY - touchStartY.current;
     if (diff > 0) {
-      // Apply drag with some resistance (multiply by less than 1 for resistance)
-      setDragOffset(diff * 0.7);
-
-      // Prevent scrolling while dragging
+      setDragOffset(diff * DRAG_RESISTANCE);
       e.preventDefault();
     }
   };
 
-  // Handle touch end event
   const handleTouchEnd = () => {
     if (!isDragging) return;
-
-    // If dragged more than 150px, close the sidebar
-    if (dragOffset > 150 && toggleSidebar) {
-      toggleSidebar();
-    }
-
-    // Reset drag state with animation
+    if (dragOffset > CLOSE_DRAG_THRESHOLD) toggleSidebar?.();
     setIsDragging(false);
     setDragOffset(0);
     touchStartY.current = null;
   };
 
-  // Handle scroll event - Fixed to only close when scrolling DOWN the sidebar
   const handleScroll = useCallback(() => {
     if (!sidebarRef.current) return;
-
-    const scrollTop = sidebarRef.current.scrollTop;
-    const isScrollingDown = scrollTop > lastScrollTop.current;
-
-    // If scrolling down (increasing scrollTop) AND we're near the top of the sidebar,
-    // close the sidebar
-    if (scrollTop < 10 && isScrollingDown && toggleSidebar && isSidebarOpen) {
-      toggleSidebar();
+    const { scrollTop } = sidebarRef.current;
+    if (scrollTop < 10 && scrollTop > lastScrollTop.current && isSidebarOpen) {
+      toggleSidebar?.();
     }
-
     lastScrollTop.current = scrollTop;
-  }, [toggleSidebar, isSidebarOpen]);
+  }, [isSidebarOpen, toggleSidebar]);
 
-  // Add and remove scroll event listener
   useEffect(() => {
     const sidebar = sidebarRef.current;
-    if (sidebar) {
-      sidebar.addEventListener("scroll", handleScroll);
-      return () => {
-        sidebar.removeEventListener("scroll", handleScroll);
-      };
-    }
+    if (!sidebar) return;
+    sidebar.addEventListener("scroll", handleScroll);
+    return () => sidebar.removeEventListener("scroll", handleScroll);
   }, [handleScroll]);
 
-  if (!isSidebarOpen) return null;
+  if (!isMounted) return null;
+
+  const hiddenTransform = isDesktop ? "translateX(-100%)" : "translateY(100%)";
+  const visibleTransform = isDesktop
+    ? `translateX(${-dragOffset}px)`
+    : `translateY(${dragOffset}px)`;
 
   return (
     <div
@@ -143,37 +140,26 @@ const FilterHadithSidebar = ({ isSidebarOpen, toggleSidebar }: Props) => {
       onTouchEnd={handleTouchEnd}
       onTouchCancel={handleTouchEnd}
       style={{
-        transform: `translateY(${dragOffset}px)`,
-        transition: isDragging ? "none" : "transform 0.3s ease-out",
+        transform: isVisible ? visibleTransform : hiddenTransform,
+        opacity: isVisible ? 1 : 0,
+        transition: isDragging
+          ? "none"
+          : `transform ${ANIMATION_MS}ms ${isSidebarOpen ? "cubic-bezier(0.22, 1, 0.36, 1)" : "cubic-bezier(0.4, 0, 1, 1)"}, opacity ${ANIMATION_MS}ms ease`,
       }}
       className={`
-        transition-all duration-300 ease-in-out
-        ${isSidebarOpen ? "opacity-100" : "opacity-0 pointer-events-none"}
-        
-        /* Desktop styles - side positioning */
-        md:w-80 md:h-full md:shadow-md md:border-r md:border-gray-100 md:bg-white
-        
-        /* Mobile styles - bottom positioning */
-        fixed bottom-0 left-0 right-0 
-        md:relative
-        bg-white
-        max-h-[80vh] md:max-h-full
-        overflow-y-auto
-        rounded-t-2xl md:rounded-none
-        shadow-lg
-        z-50
-        p-4 md:p-0
+        fixed bottom-0 left-0 right-0 z-50
+        bg-white rounded-t-2xl shadow-lg
+        max-h-[80vh] overflow-y-auto p-4
+        md:relative md:right-auto md:w-80 md:h-full md:max-h-full
+        md:rounded-none md:shadow-md md:border-r md:border-gray-100 md:p-0
       `}
     >
-      {/* Mobile handle/pull tab */}
-      <div className="drag-handle w-16 h-1 bg-gray-300 rounded-full mx-auto mb-4 md:hidden"></div>
+      <div className="drag-handle w-16 h-1 bg-gray-300 rounded-full mx-auto mb-4 md:hidden" />
 
-      {/* Search - different positioning for mobile vs desktop */}
       <div className="md:p-4">
         <Search searchTerm={localSearchTerm} handleSearchChange={handleQuery} />
       </div>
 
-      {/* Bookmarks filter */}
       <div className="mb-6 md:px-4">
         <button
           className={`w-full flex items-center justify-between p-3 text-left rounded-lg transition-colors ${
@@ -188,7 +174,6 @@ const FilterHadithSidebar = ({ isSidebarOpen, toggleSidebar }: Props) => {
         </button>
       </div>
 
-      {/* Collections dropdown */}
       <div className="md:px-4">
         <Dropdown
           type="collections"
@@ -207,7 +192,6 @@ const FilterHadithSidebar = ({ isSidebarOpen, toggleSidebar }: Props) => {
         />
       </div>
 
-      {/* Reset filters button */}
       <div className="md:px-4">
         <button
           className="w-full py-3 text-sm text-gray-500 hover:text-gray-700"

--- a/src/components/FilterHadithSidebar.tsx
+++ b/src/components/FilterHadithSidebar.tsx
@@ -22,12 +22,11 @@ const FilterHadithSidebar = ({ isSidebarOpen, toggleSidebar }: Props) => {
   const [isDragging, setIsDragging] = useState(false);
   const [isMounted, setIsMounted] = useState(isSidebarOpen);
   const [isVisible, setIsVisible] = useState(isSidebarOpen);
-  const [isDesktop, setIsDesktop] = useState(
-    () => window.matchMedia("(min-width: 768px)").matches,
-  );
+  const [isDesktop, setIsDesktop] = useState(false);
 
   useEffect(() => {
     const mq = window.matchMedia("(min-width: 768px)");
+    setIsDesktop(mq.matches);
     const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
     mq.addEventListener("change", handler);
     return () => mq.removeEventListener("change", handler);

--- a/src/components/HadithDetailsModal.tsx
+++ b/src/components/HadithDetailsModal.tsx
@@ -12,7 +12,7 @@ type Props = {
   closeHadithDetails: () => void;
   toggleBookmark: (
     id: number,
-    event: React.MouseEvent<HTMLButtonElement>
+    event: React.MouseEvent<HTMLButtonElement>,
   ) => void;
   displayLanguage: DisplayLanguage;
   copyHadithText: (text: string) => void;
@@ -77,7 +77,7 @@ const HadithDetailsModal: FC<Props> = ({
         ref={modalContentRef}
       >
         <div className="flex justify-between items-center p-3 sm:p-6 border-b border-gray-100">
-          <div className="flex items-start flex-col gap-1 sm:gap-2 max-w-full sm:max-w-[620px]">
+          <div className="flex items-start flex-col gap-1 sm:gap-2 max-w-full sm:max-w-155">
             <h2 className="text-lg sm:text-xl font-semibold line-clamp-2">
               {startCase(selectedHadith.title.toLowerCase())}
             </h2>
@@ -87,7 +87,7 @@ const HadithDetailsModal: FC<Props> = ({
             </p>
           </div>
 
-          <div className="flex items-center space-x-3 sm:space-x-4 flex-shrink-0">
+          <div className="flex items-center space-x-3 sm:space-x-4 shrink-0">
             <button
               className="text-lg text-gray-400 hover:text-yellow-500 p-1"
               style={{ transition: "color 200ms ease" }}

--- a/src/pages/hadith/index.tsx
+++ b/src/pages/hadith/index.tsx
@@ -128,7 +128,7 @@ const HadithListPage: React.FC<HadithListPageProps> = ({ initialHadithId }) => {
               >
                 ☰
               </button>
-              <h1 className="text-lg sm:text-2xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-black to-violet-300 truncate">
+              <h1 className="text-lg sm:text-2xl font-bold text-transparent bg-clip-text bg-linear-to-r from-black to-violet-300 truncate">
                 {!isMobile && (
                   <span className="text-lg sm:text-2xl mr-1 sm:mr-2">☪</span>
                 )}


### PR DESCRIPTION
## Description

This pull request introduces several improvements to the `FilterHadithSidebar` component, focusing on enhanced sidebar animation, drag behavior, and responsive design. It also includes minor UI and prop changes in the `HadithDetailsModal` and `HadithListPage` components. The most important changes are grouped below:

### Sidebar Animation & Responsive Behavior

* Added state variables and logic (`isMounted`, `isVisible`, `isDesktop`) to support smooth mounting/unmounting and responsive sidebar transitions, including a double-RAF technique for preventing animation jitter.
* Updated sidebar transform and transition styles to handle both desktop (slide-in from left) and mobile (slide-up from bottom) layouts, with improved opacity handling and custom animation curves.

### Drag & Scroll Handling

* Refactored drag and scroll logic: introduced constants for drag threshold and resistance, improved drag offset calculation, and ensured sidebar closes only when dragged or scrolled down near the top.

### UI & Styling Adjustments

* Cleaned up sidebar JSX by removing redundant comments and updating the layout classes for better consistency across devices. [[1]](diffhunk://#diff-fec5850504783d067f80cbf446a3526091ec298ec9a89bf4f4a369c76e2ec39eL146-L176) [[2]](diffhunk://#diff-fec5850504783d067f80cbf446a3526091ec298ec9a89bf4f4a369c76e2ec39eL191) [[3]](diffhunk://#diff-fec5850504783d067f80cbf446a3526091ec298ec9a89bf4f4a369c76e2ec39eL210)
* Fixed a typo in the gradient class name for the `HadithListPage` header (`bg-linear-to-r` instead of `bg-gradient-to-r`).

### Minor Component Changes

* Updated `HadithDetailsModal` props and styling: added a trailing comma to the `toggleBookmark` prop, changed `max-w` class for modal content, and replaced `flex-shrink-0` with `shrink-0` for button container. [[1]](diffhunk://#diff-198a0f2be51aefcb90922f6727b63407c7afa112c0c9dc5ce7c7a8d477edef52L15-R15) [[2]](diffhunk://#diff-198a0f2be51aefcb90922f6727b63407c7afa112c0c9dc5ce7c7a8d477edef52L80-R80) [[3]](diffhunk://#diff-198a0f2be51aefcb90922f6727b63407c7afa112c0c9dc5ce7c7a8d477edef52L90-R90)